### PR TITLE
Make Local Building Easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ The [example site](https://peteryuen.netlify.app/) shows the capabilities of `ob
 
 # Local Building
 
-To build locally
+These steps were tested on an fresh install of Ubuntu Server 20.04 install as of 12 May 2022
 
-- Use ```git clone https://github.com/trwbox/obsidian-zola``` to clone the repo to somewhere other than inside the Obsidian vault folder
+- Install zola from the instuctions on the site ```https://www.getzola.org/documentation/getting-started/installation/```
+- Run the following commands to install other needed dependencies ```sudo apt install python-is-python3 python3-pip``` and ```pip3 install python-slugify```
+- Use ```git clone https://github.com/ppeetteerrs/obsidian-zola``` to clone the repo to somewhere other than inside the Obsidian vault folder
 - Set the path to the Obsisian vault in the ```local-run.sh``` script
 - use ```./local-run.sh``` to run the site
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ providers = [
 
 The [example site](https://peteryuen.netlify.app/) shows the capabilities of `obsidian-zola`. Note that the example site uses the `dev` branch of `obsidian-zola`. If you see features that are available in the example site but are not available in the main branch yet, consider trying out the `dev` (unstable) branch. Exact method can be referenced from the [example repo's](https://github.com/ppeetteerrs/obsidian-pkm) `netlify.toml`.
 
+# Local Building
+
+To build locally
+
+- Use ```git clone https://github.com/trwbox/obsidian-zola``` to clone the repo to somewhere other than inside the Obsidian vault folder
+- Set the path to the Obsisian vault in the ```local-run.sh``` script
+- use ```./local-run.sh``` to run the site
+
 # Features 
 
 **Disclaimer**

--- a/local-run.sh
+++ b/local-run.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+# Check for python-is-python3 installed
+if ! command -v python &> /dev/null
+then
+  echo "It appears you do not have python-is-python3 installed"
+  exit 1
+fi
+
+# Check for zola being installed
+if ! command -v zola &> /dev/null
+then
+  echo "zola could not be found please install it from https://www.getzola.org/documentation/getting-started/installation"
+  exit 1
+fi
+
+# Check for correct slugify package
+PYTHON_ERROR=$(eval "python -c 'from slugify import slugify; print(slugify(\"Test String One\"))'" 2>&1)
+
+if [[ $PYTHON_ERROR != "test-string-one" ]]
+then
+  if [[ $PYTHON_ERROR =~ "NameError" ]]
+  then
+    echo "It appears you have the wrong version of slugify installed, the required pip package is python-slugify"
+  else
+    echo "It appears you do not have slugify installed. Install it with 'pip install python-slugify'"
+  fi
+  exit 1
+fi
+
 # Path to the vault
 export VAULT=""
 # Check that the vault got set

--- a/local-run.sh
+++ b/local-run.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
-# Set required environment variables (refer to build.environment in netlify.toml)
+# Path to the vault
+export VAULT=""
+# Check that the vault got set
+if [[ -z "${VAULT}" ]]; then
+  echo "Path to the obsisian vault is not set, please set the path in local-run.sh"
+  exit 1
+fi
+
+# Pull environment variables from the netlify.toml when building
+eval $(awk '/\[build.environment\]/{flag=1;next}/^\s*$/{flag=0} {if (flag && $1 != "#" && $1 != "") {printf("export %s=", $1)} if (flag && $1 != "#" && $1 != "") for(i=3;  i<=NF;  i++) if(i==NF) {printf("%s\n", $i)} else printf("%s ", $i)}' netlify.toml | sed 's/\r$//')
+
+# Set the site and repo url as local since locally built
 export SITE_URL=local
 export REPO_URL=local
-export LANDING_PAGE=home
-export SLUGIFY=y
-export HOME_GRAPH=y
-export PAGE_GRAPH=y
-export LOCAL_GRAPH=y
-export GRAPH_LINK_REPLACE=y
-export STRICT_LINE_BREAKS=y
-export SIDEBAR_COLLAPSED=y
 
 # Remove previous build and sync Zola template contents
 rm -rf build
@@ -20,9 +23,9 @@ rsync -a content/ build/content
 # Use obsidian-export to export markdown content from obsidian
 mkdir -p build/content/docs build/__docs
 if [ -z "$STRICT_LINE_BREAKS" ]; then
-	bin/obsidian-export --frontmatter=never --hard-linebreaks --no-recursive-embeds $(cat .data_path) build/__docs
+	bin/obsidian-export --frontmatter=never --hard-linebreaks --no-recursive-embeds $VAULT build/__docs
 else
-	bin/obsidian-export --frontmatter=never --no-recursive-embeds $(cat .data_path) build/__docs
+	bin/obsidian-export --frontmatter=never --no-recursive-embeds $VAULT build/__docs
 fi
 
 # Run conversion script


### PR DESCRIPTION
Made changes to the local building to use the environment variables from the netlify.toml file to not require setting them in the script manually, alongside adding a variable to have the vault path with an error to make it easier to set and run quickly after pulling. Also updated the readme to include a very brief description on building locally.