### PR TITLE
Add support for a non-root base path

### DIFF
--- a/local-run.sh
+++ b/local-run.sh
@@ -44,10 +44,12 @@ fi
 
 # Pull environment variables from the vault's netlify.toml when building (by generating env.sh to be sourced)
 python env.py
+source env.sh && rm env.sh
 
-# Set the site and repo url as local since locally built
+# Set the site and repo url as local since locally built, alongside resetting the base path to none
 export SITE_URL=local
 export REPO_URL=local
+export BASE_PATH=""
 
 # Remove previous build and sync Zola template contents
 rm -rf build
@@ -63,7 +65,7 @@ else
 fi
 
 # Run conversion script
-source env.sh && python convert.py && rm env.sh
+python convert.py
 
 # Serve Zola site
 zola --root=build serve

--- a/netlify.example.toml
+++ b/netlify.example.toml
@@ -20,7 +20,7 @@ SITE_TITLE = "Someone's Second 🧠"
 SITE_TITLE_TAB = ""
 # (REQUIRED) Netlify site URL
 SITE_URL = ""
-# (Optional) The base path of the website if not the root (e.g. /obsidian-zola/)
+# (Optional) The base path of the website if not the root (e.g. https://example.site.com/obsidian-zola/) this need to have no leading or trailing backslahes, alongside changing the SITE_URL to reflect the new location
 BASE_PATH = ""
 # (Optional) Site Timezone
 TIMEZONE = "Asia/Hong_Kong"

--- a/netlify.example.toml
+++ b/netlify.example.toml
@@ -20,6 +20,8 @@ SITE_TITLE = "Someone's Second 🧠"
 SITE_TITLE_TAB = ""
 # (REQUIRED) Netlify site URL
 SITE_URL = ""
+# (Optional) The base path of the website if not the root (e.g. /obsidian-zola/)
+BASE_PATH = ""
 # (Optional) Site Timezone
 TIMEZONE = "Asia/Hong_Kong"
 ZOLA_VERSION = "0.15.2"

--- a/utils.py
+++ b/utils.py
@@ -117,8 +117,11 @@ class DocLink:
                 .relative_to(docs_dir)
             )
             new_rel_path = quote(str(slugify_path(new_rel_path, True)))
-
-            return f"/docs/{new_rel_path}"
+            if(Settings.options["BASE_PATH"] != ""):
+                return f"/{Settings.options['BASE_PATH']}/docs/{new_rel_path}"
+            else:
+                return f"/docs/{new_rel_path}"
+        
         except Exception:
             print(f"Invalid link found: {doc_path.old_rel_path}")
             return "/404"
@@ -254,7 +257,10 @@ class DocPath:
     def abs_url(self) -> str:
         """Returns an absolute URL to the page."""
         assert self.is_md
-        return quote(f"/docs/{str(self.new_rel_path)[:-3]}")
+        if(Settings.options['BASE_PATH'] != ""):
+            return quote(f"/{Settings.options['BASE_PATH']}/docs/{str(self.new_rel_path)[:-3]}")
+        else:
+            return quote(f"/docs/{str(self.new_rel_path)[:-3]}")
 
     def edge(self, other: str) -> Tuple[str, str]:
         """Gets an edge from page's URL to another URL."""
@@ -279,6 +285,7 @@ class Settings:
     # Default options
     options: Dict[str, Optional[str]] = {
         "SITE_URL": None,
+        "BASE_PATH": "",
         "SITE_TITLE": "Someone's Second 🧠",
         "TIMEZONE": "Asia/Hong_Kong",
         "REPO_URL": None,
@@ -438,7 +445,7 @@ def parse_graph(nodes: Dict[str, str], edges: List[Tuple[str, str]]):
             list(sorted(edge_counts.items(), key=lambda k: -k[1]))[: len(PASTEL_COLORS)]
         )
     }
-
+    
     # Generate graph data
     graph_info = {
         "nodes": [


### PR DESCRIPTION
This adds an optional BASE_PATH in the configuration file that could be used for something like example.github.io/obsidian-notebook/.

The format has BASE_PATH with no slashes `BASE_PATH = "obsidian-notebook"`, and requires that SITE_URL is changed accordingly, and including a trailing backslash to be like `SITE_URL = https://example.github.io/obsidian-zola/`