### PR TITLE
Added support for videos using a shortcode

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -132,9 +132,18 @@ class DocLink:
 
         for link in cls.get_links(line):
             abs_url = link.abs_url(doc_path)
-            parsed = parsed.replace(
-                link.combined, f"[{link.title}]({abs_url}{link.header})"
-            )
+
+            if any(link.title.endswith(ext) for ext in (".webm", ".mp4")):
+                # use shortcode for videos
+                parsed = parsed.replace(
+                    link.combined,
+                    r"{{ " + f'video(url="{abs_url}", alt="{link.title}")' + r" }}",
+                )
+            else:
+                parsed = parsed.replace(
+                    link.combined, f"[{link.title}]({abs_url}{link.header})"
+                )
+
             linked.append(abs_url)
 
         return parsed, linked

--- a/zola/templates/shortcodes/video.html
+++ b/zola/templates/shortcodes/video.html
@@ -3,4 +3,6 @@
 	{% if autoplay %} autoplay {% endif %}
 	alt="{{alt}}"
 	src="{{config.base_url}}{{url}}"
+	width="100%"
+	height="auto"
 ></video>

--- a/zola/templates/shortcodes/video.html
+++ b/zola/templates/shortcodes/video.html
@@ -1,0 +1,6 @@
+<video
+	controls
+	{% if autoplay %} autoplay {% endif %}
+	alt="{{alt}}"
+	src="{{config.base_url}}{{url}}"
+></video>


### PR DESCRIPTION
Hi!

Zola doesn't have native support for videos (it generates a simple `<a>` link).

A solution for this is using a shortcode, so I added one and modified the `utils.py` section to replace the links ending with webm and mp4 with the shorcode itself.

Thanks.

