### PR TITLE
Add feature to ignore Vault directories

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -10,6 +10,8 @@ from utils import (
     raw_dir,
     site_dir,
     write_settings,
+    get_ignore_list,
+    filter_obsidian_files
 )
 
 if __name__ == "__main__":
@@ -24,8 +26,11 @@ if __name__ == "__main__":
     edges: List[Tuple[str, str]] = []
     section_count = 0
 
-    all_paths = list(sorted(raw_dir.glob("**/*")))
-
+    all_paths = list(sorted(site_dir.glob("**/*.md")))
+    # Filter files found in an optional .zolaignore file
+    ignore_list = get_ignore_list()
+    if len(ignore_list) > 0:
+        all_paths = list(filter(filter_obsidian_files(ignore_list), all_paths))
     for path in [raw_dir, *all_paths]:
         doc_path = DocPath(path)
         if doc_path.is_file:

--- a/convert.py
+++ b/convert.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     edges: List[Tuple[str, str]] = []
     section_count = 0
 
-    all_paths = list(sorted(site_dir.glob("**/*.md")))
+    all_paths = list(sorted(site_dir.glob("**/*")))
     # Filter files found in an optional .zolaignore file
     ignore_list = get_ignore_list()
     if len(ignore_list) > 0:

--- a/run.sh
+++ b/run.sh
@@ -18,8 +18,11 @@ else
 	__site/bin/obsidian-export --frontmatter=never --no-recursive-embeds __obsidian __site/build/__docs
 fi
 
+echo listing local files:
 ls .
+echo listing __site files:
 ls __site
+echo listing __obsidian files:
 ls __obsidian
 # Run conversion script
 python __site/convert.py

--- a/run.sh
+++ b/run.sh
@@ -18,12 +18,14 @@ else
 	__site/bin/obsidian-export --frontmatter=never --no-recursive-embeds __obsidian __site/build/__docs
 fi
 
+echo "$PWD"
+
 echo listing local files:
-ls .
+ls -a .
 echo listing __site files:
-ls __site
+ls -a __site
 echo listing __obsidian files:
-ls __obsidian
+ls -a __obsidian
 # Run conversion script
 python __site/convert.py
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 pip install python-slugify
 
 # Avoid copying over netlify.toml (will ebe exposed to public API)
@@ -17,6 +18,9 @@ else
 	__site/bin/obsidian-export --frontmatter=never --no-recursive-embeds __obsidian __site/build/__docs
 fi
 
+ls .
+ls __site
+ls __obsidian
 # Run conversion script
 python __site/convert.py
 

--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,6 @@ from urllib.parse import quote, unquote
 from slugify import slugify
 
 site_dir = Path(__file__).parent.absolute() / "build"
-obsidian_path = Path(__file__).parent.parent.absolute() / "__obsidian"
 raw_dir = site_dir / "__docs"
 docs_dir = site_dir / "content/docs"
 
@@ -495,8 +494,7 @@ def write_settings():
 
 
 def get_ignore_list():
-    print("Obsidian folder: " + str(obsidian_path))
-    ignore_file = obsidian_path / ".zolaignore"
+    ignore_file = site_dir.parent / ".zolaignore"
     ignore_list = []
     if ignore_file.exists():
         print("found ignore file, processing...")

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,7 @@ from urllib.parse import quote, unquote
 from slugify import slugify
 
 site_dir = Path(__file__).parent.absolute() / "build"
+obsidian_path = Path(__file__).parent.parent / "__obsidian"
 raw_dir = site_dir / "__docs"
 docs_dir = site_dir / "content/docs"
 
@@ -494,8 +495,8 @@ def write_settings():
 
 
 def get_ignore_list():
-    print("Target dir is: " + str(site_dir))
-    ignore_file = site_dir.parent / ".zolaignore"
+    print("Obsidian folder: " + str(obsidian_path))
+    ignore_file = obsidian_path / ".zolaignore"
     ignore_list = []
     if ignore_file.exists():
         print("found ignore file, processing...")

--- a/utils.py
+++ b/utils.py
@@ -506,5 +506,9 @@ def get_ignore_list():
     print("No ignore file found.")
     return []
 
+def trace(a):
+    print(a)
+    return a
+
 def filter_obsidian_files(ignore_list):
-    return lambda a: next(filter(lambda x: PurePath(a).parent == site_dir.parent / x, ignore_list), None) is None
+    return lambda a: next(filter(lambda x: trace(PurePath(a).parent) == trace(x), ignore_list), None) is None

--- a/utils.py
+++ b/utils.py
@@ -494,14 +494,18 @@ def write_settings():
 
 
 def get_ignore_list():
-    ignore_file = site_dir / ".zolaignore"
+    print("Target dir is: " + site_dir)
+    ignore_file = site_dir.parent / ".zolaignore"
     ignore_list = []
     if ignore_file.exists():
+        print("found ignore file, processing...")
         with open(ignore_file, encoding="utf-8") as f:
             for line in f:
+                print("ignoring " + line + "/")
                 ignore_list.append(line)
         return ignore_list
+    print("No ignore file found.")
     return []
 
 def filter_obsidian_files(ignore_list):
-    return lambda a: next(filter(lambda x: PurePath(a).parent == site_dir / x, ignore_list), None) is None
+    return lambda a: next(filter(lambda x: PurePath(a).parent == site_dir.parent / x, ignore_list), None) is None

--- a/utils.py
+++ b/utils.py
@@ -511,4 +511,4 @@ def trace(a):
     return a
 
 def filter_obsidian_files(ignore_list):
-    return lambda a: next(filter(lambda x: trace(PurePath(a).parent) == trace(x), ignore_list), None) is None
+    return lambda a: next(filter(lambda x: a.match(x), ignore_list), None) is None

--- a/utils.py
+++ b/utils.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from distutils.util import strtobool
 from os import environ
-from pathlib import Path, PurePath
+from pathlib import Path
 from pprint import PrettyPrinter
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import quote, unquote
@@ -500,7 +500,7 @@ def get_ignore_list():
         print("found ignore file, processing...")
         with open(ignore_file, encoding="utf-8") as f:
             for line in f:
-                print("ignoring " + line + "/")
+                print("ignoring " + line)
                 ignore_list.append(line)
         return ignore_list
     print("No ignore file found.")

--- a/utils.py
+++ b/utils.py
@@ -494,7 +494,7 @@ def write_settings():
 
 
 def get_ignore_list():
-    print("Target dir is: " + site_dir)
+    print("Target dir is: " + str(site_dir))
     ignore_file = site_dir.parent / ".zolaignore"
     ignore_list = []
     if ignore_file.exists():

--- a/utils.py
+++ b/utils.py
@@ -7,12 +7,12 @@ from dataclasses import dataclass
 from datetime import datetime
 from distutils.util import strtobool
 from os import environ
-from pathlib import Path
+from pathlib import Path, PurePath
 from pprint import PrettyPrinter
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import quote, unquote
 
-from slugify import slugify
+# from slugify import slugify
 
 site_dir = Path(__file__).parent.absolute() / "build"
 raw_dir = site_dir / "__docs"
@@ -491,3 +491,17 @@ def write_settings():
                 ]
             )
         )
+
+
+def get_ignore_list():
+    ignore_file = site_dir / ".zolaignore"
+    ignore_list = []
+    if ignore_file.exists():
+        with open(ignore_file, encoding="utf-8") as f:
+            for line in f:
+                ignore_list.append(line)
+        return ignore_list
+    return []
+
+def filter_obsidian_files(ignore_list):
+    return lambda a: next(filter(lambda x: PurePath(a).parent == site_dir / x, ignore_list), None) is None

--- a/utils.py
+++ b/utils.py
@@ -494,7 +494,7 @@ def write_settings():
 
 
 def get_ignore_list():
-    ignore_file = site_dir.parent / ".zolaignore"
+    ignore_file = site_dir.parent.parent / ".zolaignore"
     ignore_list = []
     if ignore_file.exists():
         print("found ignore file, processing...")

--- a/utils.py
+++ b/utils.py
@@ -12,7 +12,7 @@ from pprint import PrettyPrinter
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import quote, unquote
 
-# from slugify import slugify
+from slugify import slugify
 
 site_dir = Path(__file__).parent.absolute() / "build"
 raw_dir = site_dir / "__docs"

--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,7 @@ from urllib.parse import quote, unquote
 from slugify import slugify
 
 site_dir = Path(__file__).parent.absolute() / "build"
-obsidian_path = Path(__file__).parent.parent / "__obsidian"
+obsidian_path = Path(__file__).parent.parent.absolute() / "__obsidian"
 raw_dir = site_dir / "__docs"
 docs_dir = site_dir / "content/docs"
 


### PR DESCRIPTION
I encountered the problem, that I have some workfiles in my Vault I want to be ignored, like templates.
In the spirit of .gitignore ignoring files for git, I implemented a support for ignoring files in zola specifically with a .zoraignore file.
It also supports globs like .gitignore, which makes it intuitive to understand. I hope you find this contribution helpful!