### PR TITLE
ADD option to ignore certain files with a .zolaignore

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -10,6 +10,8 @@ from utils import (
     raw_dir,
     site_dir,
     write_settings,
+    get_ignore_list,
+    filter_obsidian_files
 )
 
 if __name__ == "__main__":
@@ -24,8 +26,11 @@ if __name__ == "__main__":
     edges: List[Tuple[str, str]] = []
     section_count = 0
 
-    all_paths = list(sorted(raw_dir.glob("**/*")))
-
+    all_paths = list(sorted(site_dir.glob("**/*")))
+    # Filter files found in an optional .zolaignore file
+    ignore_list = get_ignore_list()
+    if len(ignore_list) > 0:
+        all_paths = list(filter(filter_obsidian_files(ignore_list), all_paths))
     for path in [raw_dir, *all_paths]:
         doc_path = DocPath(path)
         if doc_path.is_file:

--- a/utils.py
+++ b/utils.py
@@ -491,3 +491,24 @@ def write_settings():
                 ]
             )
         )
+
+
+def get_ignore_list():
+    ignore_file = site_dir.parent.parent / ".zolaignore"
+    ignore_list = []
+    if ignore_file.exists():
+        print("found ignore file, processing...")
+        with open(ignore_file, encoding="utf-8") as f:
+            for line in f:
+                print("ignoring " + line)
+                ignore_list.append(line)
+        return ignore_list
+    print("No ignore file found.")
+    return []
+
+def trace(a):
+    print(a)
+    return a
+
+def filter_obsidian_files(ignore_list):
+    return lambda a: next(filter(lambda x: a.match(x), ignore_list), None) is None


### PR DESCRIPTION
I encountered the problem, that I have some workfiles in my Vault I want to be ignored, like templates.
In the spirit of .gitignore ignoring files for git, I implemented a support for ignoring files in zola specifically with a .zoraignore file.
It also supports globs like .gitignore, which makes it intuitive to understand. 

I hope you find this contribution helpful!
Tell if I can add anything else to this PR to meet your requirements.

Cheers, Seb